### PR TITLE
Add task list with tags and filter

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,41 @@
 #root {
-  max-width: 1280px;
+  max-width: 640px;
   margin: 0 auto;
   padding: 2rem;
   text-align: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.add-task input {
+  margin-right: 0.5rem;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.filter {
+  margin: 1rem 0;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
+.task-list {
+  list-style: none;
+  padding: 0;
 }
 
-.card {
-  padding: 2em;
+.task-list li {
+  margin: 0.5rem 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
-.read-the-docs {
+.task-list li.completed {
+  color: gray;
+  text-decoration: line-through;
+}
+
+.tag {
+  margin-left: 0.5rem;
+  font-size: 0.8rem;
   color: #888;
+}
+
+.delete {
+  margin-left: 0.5rem;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,35 +1,110 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
 
-function App() {
-  const [count, setCount] = useState(0)
-
-  return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+interface Task {
+  id: number
+  text: string
+  tags: string[]
+  completed: boolean
 }
 
-export default App
+export default function App() {
+  const [tasks, setTasks] = useState<Task[]>([])
+  const [text, setText] = useState('')
+  const [tags, setTags] = useState('')
+  const [filterTag, setFilterTag] = useState('')
+
+  const addTask = () => {
+    const trimmed = text.trim()
+    if (!trimmed) return
+    const newTask: Task = {
+      id: Date.now(),
+      text: trimmed,
+      tags: tags
+        .split(/\s+/)
+        .map((t) => t.trim())
+        .filter((t) => t.length > 0),
+      completed: false,
+    }
+    setTasks([...tasks, newTask])
+    setText('')
+    setTags('')
+  }
+
+  const toggleComplete = (id: number) => {
+    setTasks((prev) =>
+      prev.map((task) =>
+        task.id === id ? { ...task, completed: !task.completed } : task,
+      ),
+    )
+  }
+
+  const removeTask = (id: number) => {
+    setTasks((prev) => prev.filter((task) => task.id !== id))
+  }
+
+  const uniqueTags = Array.from(new Set(tasks.flatMap((t) => t.tags)))
+  const visibleTasks = filterTag
+    ? tasks.filter((t) => t.tags.includes(filterTag))
+    : tasks
+
+  return (
+    <div className="todo-app">
+      <h1>ToDo List</h1>
+      <div className="add-task">
+        <input
+          placeholder="New task"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+        />
+        <input
+          placeholder="Tags (space separated)"
+          value={tags}
+          onChange={(e) => setTags(e.target.value)}
+        />
+        <button onClick={addTask}>Add</button>
+      </div>
+      <div className="filter">
+        <label>
+          Filter by tag:
+          <select
+            value={filterTag}
+            onChange={(e) => setFilterTag(e.target.value)}
+          >
+            <option value="">All</option>
+            {uniqueTags.map((tag) => (
+              <option key={tag} value={tag}>
+                {tag}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <ul className="task-list">
+        {visibleTasks.map((task) => (
+          <li
+            key={task.id}
+            className={task.completed ? 'completed' : undefined}
+          >
+            <label>
+              <input
+                type="checkbox"
+                checked={task.completed}
+                onChange={() => toggleComplete(task.id)}
+              />
+              {task.text}
+            </label>
+            {task.tags.map((tag) => (
+              <span key={tag} className="tag">
+                #{tag}
+              </span>
+            ))}
+            <button className="delete" onClick={() => removeTask(task.id)}>
+              Delete
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- replace default React sample with a Todo app
- allow adding/removing tasks with space-separated tags
- filter tasks by tag with a dropdown
- completed tasks are greyed out

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_684a8307d4ec83299df1f285b5bda3dc